### PR TITLE
Screens/parliament screen

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,11 +6,7 @@
   <component name="ChangeListManager">
     <list default="true" id="940e75ed-a3fe-4fda-aab8-c6d80cc05012" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/ParliamentController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/ParliamentController.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/components/ParliamentRenderer.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/components/ParliamentRenderer.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/components/TooltipManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/components/TooltipManager.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/parliament.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/parliament.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/view/ParliamentView.fxml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/view/ParliamentView.fxml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -202,7 +198,7 @@
       <workItem from="1767544145939" duration="1705000" />
       <workItem from="1767619857062" duration="606000" />
       <workItem from="1767633030896" duration="615000" />
-      <workItem from="1767645087297" duration="4532000" />
+      <workItem from="1767645087297" duration="5388000" />
     </task>
     <task id="LOCAL-00001" summary="workspace.xml changed">
       <option name="closed" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,13 +5,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="940e75ed-a3fe-4fda-aab8-c6d80cc05012" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/ParliamentController.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/components/ParliamentRenderer.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/parliament.css" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/view/ParliamentView.fxml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/DashboardController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/DashboardController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/view/DashboardUI.fxml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/view/DashboardUI.fxml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/ParliamentController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/ParliamentController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/components/ParliamentRenderer.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/components/ParliamentRenderer.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/components/TooltipManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/components/TooltipManager.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/parliament.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/parliament.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/view/ParliamentView.fxml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/view/ParliamentView.fxml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -203,7 +202,7 @@
       <workItem from="1767544145939" duration="1705000" />
       <workItem from="1767619857062" duration="606000" />
       <workItem from="1767633030896" duration="615000" />
-      <workItem from="1767645087297" duration="1569000" />
+      <workItem from="1767645087297" duration="4532000" />
     </task>
     <task id="LOCAL-00001" summary="workspace.xml changed">
       <option name="closed" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,15 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="940e75ed-a3fe-4fda-aab8-c6d80cc05012" name="Changes" comment="" />
+    <list default="true" id="940e75ed-a3fe-4fda-aab8-c6d80cc05012" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/ParliamentController.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/components/ParliamentRenderer.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/parliament.css" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/view/ParliamentView.fxml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/DashboardController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/de/schulprojekt/duv/view/DashboardController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/view/DashboardUI.fxml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/de/schulprojekt/duv/view/DashboardUI.fxml" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -55,38 +63,38 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;Application.Main.executor&quot;: &quot;Run&quot;,
-    &quot;Maven.Build EXE.executor&quot;: &quot;Run&quot;,
-    &quot;Maven.DUV - run.executor&quot;: &quot;Run&quot;,
-    &quot;Maven.Das-Unberechenbare-Volk [clean].executor&quot;: &quot;Run&quot;,
-    &quot;Maven.Das-Unberechenbare-Volk [install].executor&quot;: &quot;Run&quot;,
-    &quot;Maven.Das-Unberechenbare-Volk [package].executor&quot;: &quot;Run&quot;,
-    &quot;Maven.Package &amp; Install.executor&quot;: &quot;Run&quot;,
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;Screens/Statistic-Screen&quot;,
-    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;D:/4_Projekte/IntelliJ/Das-Unberechenbare-Volk&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
-    &quot;project.structure.proportion&quot;: &quot;0.15&quot;,
-    &quot;project.structure.side.proportion&quot;: &quot;0.2&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settings.project.maven.runner&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "Application.Main.executor": "Run",
+    "Maven.Build EXE.executor": "Run",
+    "Maven.DUV - run.executor": "Run",
+    "Maven.Das-Unberechenbare-Volk [clean].executor": "Run",
+    "Maven.Das-Unberechenbare-Volk [install].executor": "Run",
+    "Maven.Das-Unberechenbare-Volk [package].executor": "Run",
+    "Maven.Package & Install.executor": "Run",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "git-widget-placeholder": "Screens/Parliament-Screen",
+    "ignore.virus.scanning.warn.message": "true",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "D:/4_Projekte/IntelliJ/Das-Unberechenbare-Volk",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "project.structure.last.edited": "Project",
+    "project.structure.proportion": "0.15",
+    "project.structure.side.proportion": "0.2",
+    "settings.editor.selected.configurable": "reference.settings.project.maven.runner",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="D:\4_Projekte\IntelliJ\Das-Unberechenbare-Volk\src\main\resources\de\schulprojekt\duv" />
@@ -195,6 +203,7 @@
       <workItem from="1767544145939" duration="1705000" />
       <workItem from="1767619857062" duration="606000" />
       <workItem from="1767633030896" duration="615000" />
+      <workItem from="1767645087297" duration="1569000" />
     </task>
     <task id="LOCAL-00001" summary="workspace.xml changed">
       <option name="closed" value="true" />

--- a/src/main/java/de/schulprojekt/duv/view/DashboardController.java
+++ b/src/main/java/de/schulprojekt/duv/view/DashboardController.java
@@ -234,6 +234,42 @@ public class DashboardController {
         }
     }
 
+    @FXML
+    public void handleShowParliament(ActionEvent event) {
+        if (controller == null) return;
+
+        // Simulation pausieren
+        if (controller.isRunning()) {
+            handlePauseSimulation(null);
+        }
+
+        try {
+            // Lade die FXML für die Parlamentsansicht
+            var resource = getClass().getResource("/de/schulprojekt/duv/view/ParliamentView.fxml");
+            if (resource == null) {
+                System.err.println("FEHLER: ParliamentView.fxml nicht gefunden!");
+                return;
+            }
+
+            FXMLLoader loader = new FXMLLoader(resource);
+            Parent parliamentRoot = loader.load();
+            ParliamentController parlCtrl = loader.getController();
+
+            // Aktuelle View merken (für den Zurück-Button)
+            Parent dashboardView = startButton.getScene().getRoot();
+
+            // Daten übergeben
+            parlCtrl.initData(controller.getParties(), dashboardView);
+
+            // Ansicht wechseln
+            startButton.getScene().setRoot(parliamentRoot);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            new javafx.scene.control.Alert(javafx.scene.control.Alert.AlertType.ERROR, "Fehler beim Laden: " + e.getMessage()).show();
+        }
+    }
+
     @FXML public void handleVoterCountIncrement(ActionEvent e) { adjustIntField(voterCountField, 10000, 1000, 2000000); }
     @FXML public void handleVoterCountDecrement(ActionEvent e) { adjustIntField(voterCountField, -10000, 1000, 2000000); }
     @FXML public void handlePartyCountIncrement(ActionEvent e) { adjustIntField(partyCountField, 1, 2, 8); }

--- a/src/main/java/de/schulprojekt/duv/view/ParliamentController.java
+++ b/src/main/java/de/schulprojekt/duv/view/ParliamentController.java
@@ -1,0 +1,45 @@
+package de.schulprojekt.duv.view;
+
+import de.schulprojekt.duv.model.party.Party;
+import de.schulprojekt.duv.view.components.ParliamentRenderer;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.scene.Parent;
+import javafx.scene.layout.Pane;
+import java.util.List;
+
+public class ParliamentController {
+
+    @FXML private Pane canvasContainer;
+
+    private ParliamentRenderer renderer;
+    private Parent previousView;
+
+    /**
+     * Initialisiert die Daten und startet den Renderer.
+     * @param parties Die Liste der aktuellen Parteien
+     * @param previousView Die View (Root-Node), zu der wir zurückkehren wollen (Dashboard)
+     */
+    public void initData(List<Party> parties, Parent previousView) {
+        this.previousView = previousView;
+
+        // Renderer initialisieren (zeichnet auf canvasContainer)
+        this.renderer = new ParliamentRenderer(canvasContainer);
+
+        // Zeichnung starten
+        this.renderer.renderDistribution(parties);
+    }
+
+    @FXML
+    public void handleBack(ActionEvent event) {
+        // Animation stoppen, um Ressourcen zu sparen
+        if (renderer != null) {
+            renderer.stop();
+        }
+
+        // Zurück zum Dashboard navigieren
+        if (previousView != null) {
+            canvasContainer.getScene().setRoot(previousView);
+        }
+    }
+}

--- a/src/main/java/de/schulprojekt/duv/view/ParliamentController.java
+++ b/src/main/java/de/schulprojekt/duv/view/ParliamentController.java
@@ -2,6 +2,7 @@ package de.schulprojekt.duv.view;
 
 import de.schulprojekt.duv.model.party.Party;
 import de.schulprojekt.duv.view.components.ParliamentRenderer;
+import de.schulprojekt.duv.view.components.TooltipManager;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.Parent;
@@ -13,33 +14,40 @@ public class ParliamentController {
     @FXML private Pane canvasContainer;
 
     private ParliamentRenderer renderer;
+    private TooltipManager tooltipManager;
     private Parent previousView;
 
-    /**
-     * Initialisiert die Daten und startet den Renderer.
-     * @param parties Die Liste der aktuellen Parteien
-     * @param previousView Die View (Root-Node), zu der wir zurückkehren wollen (Dashboard)
-     */
     public void initData(List<Party> parties, Parent previousView) {
         this.previousView = previousView;
 
-        // Renderer initialisieren (zeichnet auf canvasContainer)
         this.renderer = new ParliamentRenderer(canvasContainer);
+        this.tooltipManager = new TooltipManager(canvasContainer);
 
-        // Zeichnung starten
         this.renderer.renderDistribution(parties);
+
+        // Hover: Leuchten
+        canvasContainer.setOnMouseMoved(event -> {
+            Party hovered = renderer.getPartyAt(event.getX(), event.getY());
+            renderer.setHoveredParty(hovered);
+        });
+
+        // Klick: Tooltip & Selektion
+        canvasContainer.setOnMouseClicked(event -> {
+            Party clickedParty = renderer.getPartyAt(event.getX(), event.getY());
+            if (clickedParty != null) {
+                renderer.setSelectedParty(clickedParty);
+                double[] center = renderer.getPartyCenterCoordinates(clickedParty);
+                tooltipManager.showStaticTooltip(clickedParty, center[0], center[1]);
+            } else {
+                renderer.setSelectedParty(null);
+                tooltipManager.hideTooltip();
+            }
+        });
     }
 
     @FXML
     public void handleBack(ActionEvent event) {
-        // Animation stoppen, um Ressourcen zu sparen
-        if (renderer != null) {
-            renderer.stop();
-        }
-
-        // Zurück zum Dashboard navigieren
-        if (previousView != null) {
-            canvasContainer.getScene().setRoot(previousView);
-        }
+        if (renderer != null) renderer.stop();
+        if (previousView != null) canvasContainer.getScene().setRoot(previousView);
     }
 }

--- a/src/main/java/de/schulprojekt/duv/view/components/ParliamentRenderer.java
+++ b/src/main/java/de/schulprojekt/duv/view/components/ParliamentRenderer.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 
 /**
  * High-Density "War Room" Parliament Renderer.
- * Korrigiert: Voller 180-Grad-Bogen, keine Lücken, exakte Skalierung.
+ * Version: Clean & Fixed (Voller 180-Grad-Bogen, keine extra Linien).
  */
 public class ParliamentRenderer {
 
@@ -134,15 +134,16 @@ public class ParliamentRenderer {
 
     private void calculateSeatPositions(List<Party> parties) {
         seats.clear();
-        double totalVotes = parties.stream().mapToDouble(Party::getCurrentSupporterCount).sum();
 
-        // 1. Sortieren nach politischer Position
+        // 1. Sortieren nach politischer Position und Filterung
         List<Party> sortedParties = parties.stream()
                 .filter(p -> !p.getName().equals(SimulationConfig.UNDECIDED_NAME))
                 .sorted(Comparator.comparingDouble(Party::getPoliticalPosition))
                 .collect(Collectors.toList());
 
-        // 2. Sitze verteilen (Exakt TOTAL_SEATS füllen)
+        // 2. Sitze verteilen (Basis ist nur die Summe der angezeigten Parteien!)
+        double totalVotes = sortedParties.stream().mapToDouble(Party::getCurrentSupporterCount).sum();
+
         List<Party> seatPartyMap = new ArrayList<>();
         if (totalVotes > 0) {
             for (Party p : sortedParties) {
@@ -157,7 +158,7 @@ public class ParliamentRenderer {
             seatPartyMap.remove(seatPartyMap.size() - 1);
         }
         while (seatPartyMap.size() < TOTAL_SEATS) {
-            seatPartyMap.add(null); // Leere Sitze auffüllen
+            seatPartyMap.add(null); // Auffüllen falls Rundungsdifferenzen
         }
 
         // 3. Geometrie berechnen (Verteilung auf Reihen)
@@ -337,6 +338,7 @@ public class ParliamentRenderer {
     }
 
     private void drawNetwork(GraphicsContext gc, double cx, double cy, double scale, double t) {
+        // Original implementation: Nur subtile Linien zur Mitte
         gc.setStroke(Color.web("#D4AF37", 0.05));
         gc.setLineWidth(1.0);
         int step = 10;

--- a/src/main/java/de/schulprojekt/duv/view/components/ParliamentRenderer.java
+++ b/src/main/java/de/schulprojekt/duv/view/components/ParliamentRenderer.java
@@ -1,0 +1,193 @@
+package de.schulprojekt.duv.view.components;
+
+import de.schulprojekt.duv.model.party.Party;
+import de.schulprojekt.duv.util.SimulationConfig;
+import javafx.animation.AnimationTimer;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.effect.Glow;
+import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
+import javafx.scene.text.TextAlignment;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Zeichnet das Parlament mit politischer Sortierung (Links -> Rechts).
+ */
+public class ParliamentRenderer {
+
+    private final Canvas canvas;
+    private final List<Seat> seats = new ArrayList<>();
+    private AnimationTimer introAnimation;
+    private static final int TOTAL_SEATS = 300; // Mehr Sitze für dichtere Optik
+    private static final int ROWS = 10;         // Mehr Reihen
+
+    public ParliamentRenderer(Pane parentPane) {
+        this.canvas = new Canvas(parentPane.getWidth(), parentPane.getHeight());
+        canvas.widthProperty().bind(parentPane.widthProperty());
+        canvas.heightProperty().bind(parentPane.heightProperty());
+        parentPane.getChildren().add(canvas);
+
+        canvas.widthProperty().addListener(obs -> { if(!seats.isEmpty()) draw(10.0); });
+        canvas.heightProperty().addListener(obs -> { if(!seats.isEmpty()) draw(10.0); });
+    }
+
+    public void renderDistribution(List<Party> parties) {
+        calculateSeatPositions(parties);
+        startAnimation();
+    }
+
+    public void stop() {
+        if (introAnimation != null) introAnimation.stop();
+    }
+
+    private void calculateSeatPositions(List<Party> parties) {
+        seats.clear();
+        double totalVotes = parties.stream().mapToDouble(Party::getCurrentSupporterCount).sum();
+
+        // 1. Sortierung nach politischem Spektrum (DE-Standard)
+        List<Party> sortedParties = parties.stream()
+                .filter(p -> !p.getName().equals(SimulationConfig.UNDECIDED_NAME))
+                .sorted(new SpectrumComparator())
+                .collect(Collectors.toList());
+
+        // 2. Farb-Liste erstellen (Ein Eintrag pro Sitz)
+        List<String> seatColorMap = new ArrayList<>();
+
+        for (Party p : sortedParties) {
+            double share = (totalVotes > 0) ? p.getCurrentSupporterCount() / totalVotes : 0;
+            int seatsForParty = (int) Math.round(share * TOTAL_SEATS);
+
+            for (int i = 0; i < seatsForParty; i++) {
+                if (seatColorMap.size() < TOTAL_SEATS) {
+                    seatColorMap.add(p.getColorCode());
+                }
+            }
+        }
+        // Auffüllen mit Grau, falls Rundungsfehler
+        while (seatColorMap.size() < TOTAL_SEATS) {
+            seatColorMap.add("444444");
+        }
+
+        // 3. Geometrische Berechnung der Sitze (Halbkreis)
+        // Wir berechnen ALLE Sitzpositionen im Saal, sortieren sie von Links nach Rechts
+        // und weisen dann die Farben zu. Das garantiert perfekte Blöcke.
+
+        List<Point> layoutPoints = new ArrayList<>();
+        double startRadius = 100.0;
+        double rowStep = 25.0; // Engere Reihen
+
+        for (int row = 0; row < ROWS; row++) {
+            double currentRadius = startRadius + (row * rowStep);
+            double arcLength = Math.PI * currentRadius;
+
+            // Proportionale Anzahl Sitze pro Reihe
+            double totalArcParams = 0;
+            for(int r=0; r<ROWS; r++) totalArcParams += Math.PI * (startRadius + (r * rowStep));
+            int seatsInRow = (int) (TOTAL_SEATS * (arcLength / totalArcParams));
+
+            double angleStep = Math.PI / (seatsInRow + 1);
+
+            for (int s = 0; s < seatsInRow; s++) {
+                // Winkel von PI (Links) bis 0 (Rechts)
+                double angle = Math.PI - (angleStep * (s + 1));
+
+                // Koordinaten (Relativ zur Mitte)
+                double x = Math.cos(angle) * currentRadius;
+                double y = -Math.sin(angle) * currentRadius; // Nach oben
+
+                // Wir speichern den Winkel für die spätere Sortierung
+                layoutPoints.add(new Point(x, y, angle));
+            }
+        }
+
+        // 4. Sortieren der physikalischen Plätze von LINKS (großer Winkel) nach RECHTS (kleiner Winkel)
+        // Damit füllen wir die Parteien "streifenweise" auf.
+        layoutPoints.sort((p1, p2) -> Double.compare(p2.angle, p1.angle));
+
+        // 5. Farben zuweisen
+        int limit = Math.min(layoutPoints.size(), seatColorMap.size());
+        for (int i = 0; i < limit; i++) {
+            Point pt = layoutPoints.get(i);
+            seats.add(new Seat(pt.x, pt.y, seatColorMap.get(i)));
+        }
+    }
+
+    /**
+     * Sortiert Parteien nach deutscher Parlamentslogik (Links -> Rechts).
+     */
+    private static class SpectrumComparator implements Comparator<Party> {
+        @Override
+        public int compare(Party p1, Party p2) {
+            return Integer.compare(getSpectrumIndex(p1), getSpectrumIndex(p2));
+        }
+
+        private int getSpectrumIndex(Party p) {
+            String name = p.getName().toLowerCase();
+            String abbr = p.getAbbreviation().toLowerCase();
+
+            // Index: 0 (Links) bis 10 (Rechts)
+            if (name.contains("linke") || abbr.contains("linke")) return 0;
+            if (name.contains("spd") || abbr.contains("spd") || name.contains("sozial")) return 1;
+            if (name.contains("grüne") || abbr.contains("grüne") || name.contains("green")) return 2;
+            if (name.contains("fdp") || abbr.contains("fdp") || name.contains("libera")) return 3;
+            if (name.contains("cdu") || abbr.contains("cdu") || name.contains("csu") || name.contains("christ")) return 4;
+            if (name.contains("afd") || abbr.contains("afd") || name.contains("alternative")) return 5;
+
+            return 10; // Sonstige (ganz rechts außen oder separat)
+        }
+    }
+
+    private void startAnimation() {
+        final long startNano = System.nanoTime();
+        introAnimation = new AnimationTimer() {
+            @Override
+            public void handle(long now) {
+                double t = (now - startNano) / 1_000_000_000.0;
+                draw(t);
+                if (t > 2.0) stop();
+            }
+        };
+        introAnimation.start();
+    }
+
+    private void draw(double time) {
+        GraphicsContext gc = canvas.getGraphicsContext2D();
+        double w = canvas.getWidth();
+        double h = canvas.getHeight();
+        double cx = w / 2;
+        double cy = h * 0.9; // Basis weit unten
+
+        gc.clearRect(0, 0, w, h);
+        gc.setEffect(new Glow(0.6));
+
+        double scale = Math.min(w, h) / 600.0;
+
+        for (Seat seat : seats) {
+            // Sweep von Links nach Rechts
+            double normalizedX = (seat.x + 400) / 800.0;
+            if (time < normalizedX * 1.5) continue;
+
+            gc.setFill(Color.web("#" + seat.color));
+            double drawX = cx + (seat.x * scale);
+            double drawY = cy + (seat.y * scale);
+            double size = 7.0 * scale;
+
+            gc.fillOval(drawX - size/2, drawY - size/2, size, size);
+        }
+
+        // Pult
+        gc.setFill(Color.web("#555555"));
+        gc.fillRect(cx - 30*scale, cy - 10*scale, 60*scale, 20*scale);
+
+        gc.setEffect(null);
+    }
+
+    private static class Point { double x, y, angle; Point(double x, double y, double a) {this.x=x; this.y=y; this.angle=a;} }
+    private static class Seat { double x, y; String color; Seat(double x, double y, String c) {this.x=x; this.y=y; this.color=c;} }
+}

--- a/src/main/java/de/schulprojekt/duv/view/components/ParliamentRenderer.java
+++ b/src/main/java/de/schulprojekt/duv/view/components/ParliamentRenderer.java
@@ -5,10 +5,15 @@ import de.schulprojekt.duv.util.SimulationConfig;
 import javafx.animation.AnimationTimer;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.effect.Bloom;
 import javafx.scene.effect.Glow;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
+import javafx.scene.paint.CycleMethod;
+import javafx.scene.paint.LinearGradient;
+import javafx.scene.paint.Stop;
 import javafx.scene.text.Font;
+import javafx.scene.text.FontWeight;
 import javafx.scene.text.TextAlignment;
 
 import java.util.ArrayList;
@@ -17,24 +22,54 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Zeichnet das Parlament mit politischer Sortierung (Links -> Rechts).
+ * High-Density "War Room" Parliament Renderer.
+ * Korrigiert: Voller 180-Grad-Bogen, keine Lücken, exakte Skalierung.
  */
 public class ParliamentRenderer {
 
     private final Canvas canvas;
     private final List<Seat> seats = new ArrayList<>();
-    private AnimationTimer introAnimation;
-    private static final int TOTAL_SEATS = 300; // Mehr Sitze für dichtere Optik
-    private static final int ROWS = 10;         // Mehr Reihen
+    private AnimationTimer animationLoop;
+
+    // --- Konfiguration ---
+    // Erhöhte Sitzzahl für eine dichte, geschlossene Optik
+    private static final int TOTAL_SEATS = 400;
+    private static final int ROWS = 14;
+
+    // Geometrie
+    private static final double START_RADIUS = 80.0;
+    private static final double ROW_STEP = 18.0;
+    // Maximaler Radius für Skalierungsberechnung
+    private static final double MAX_RADIUS = START_RADIUS + (ROWS * ROW_STEP);
+
+    // --- Farben ---
+    private static final Color COL_GOLD = Color.web("#D4AF37");
+    private static final Color COL_GOLD_DIM = Color.web("#D4AF37", 0.3);
+    private static final Color COL_TEXT = Color.web("#888888");
+    private static final Color COL_BG_LINES = Color.web("#2a2a2e");
+    private static final Color COL_EMPTY_SEAT = Color.web("#222222");
+
+    // Animation & State
+    private double time = 0.0;
+
+    // Interaktion
+    private double lastCx, lastCy, lastScale;
+    private Party selectedParty = null;
+    private Party hoveredParty = null;
 
     public ParliamentRenderer(Pane parentPane) {
-        this.canvas = new Canvas(parentPane.getWidth(), parentPane.getHeight());
+        this.canvas = new Canvas(0, 0);
         canvas.widthProperty().bind(parentPane.widthProperty());
         canvas.heightProperty().bind(parentPane.heightProperty());
+
+        Bloom bloom = new Bloom();
+        bloom.setThreshold(0.6);
+        canvas.setEffect(bloom);
+
         parentPane.getChildren().add(canvas);
 
-        canvas.widthProperty().addListener(obs -> { if(!seats.isEmpty()) draw(10.0); });
-        canvas.heightProperty().addListener(obs -> { if(!seats.isEmpty()) draw(10.0); });
+        canvas.widthProperty().addListener(obs -> requestDraw());
+        canvas.heightProperty().addListener(obs -> requestDraw());
     }
 
     public void renderDistribution(List<Party> parties) {
@@ -43,151 +78,332 @@ public class ParliamentRenderer {
     }
 
     public void stop() {
-        if (introAnimation != null) introAnimation.stop();
+        if (animationLoop != null) animationLoop.stop();
     }
+
+    private void requestDraw() {
+        if (!seats.isEmpty()) draw(time > 0 ? time : 10.0);
+    }
+
+    // --- Interaktion ---
+
+    public void setSelectedParty(Party p) {
+        this.selectedParty = p;
+        requestDraw();
+    }
+
+    public void setHoveredParty(Party p) {
+        if (this.hoveredParty != p) {
+            this.hoveredParty = p;
+            requestDraw();
+        }
+    }
+
+    public Party getPartyAt(double screenX, double screenY) {
+        if (lastScale == 0) return null;
+        double hitRadius = 12.0 * lastScale; // Hitbox etwas kleiner für Präzision
+
+        for (Seat seat : seats) {
+            if (seat.party == null) continue;
+            double seatScreenX = lastCx + (seat.x * lastScale);
+            double seatScreenY = lastCy + (seat.y * lastScale);
+            double dist = Math.sqrt(Math.pow(screenX - seatScreenX, 2) + Math.pow(screenY - seatScreenY, 2));
+            if (dist < hitRadius) {
+                return seat.party;
+            }
+        }
+        return null;
+    }
+
+    public double[] getPartyCenterCoordinates(Party p) {
+        if (p == null) return new double[]{lastCx, lastCy};
+        double sumX = 0, sumY = 0;
+        int count = 0;
+        for (Seat s : seats) {
+            if (p.equals(s.party)) {
+                sumX += lastCx + (s.x * lastScale);
+                sumY += lastCy + (s.y * lastScale);
+                count++;
+            }
+        }
+        if (count == 0) return new double[]{lastCx, lastCy};
+        return new double[]{sumX / count, sumY / count};
+    }
+
+    // --- Berechnung ---
 
     private void calculateSeatPositions(List<Party> parties) {
         seats.clear();
         double totalVotes = parties.stream().mapToDouble(Party::getCurrentSupporterCount).sum();
 
-        // 1. Sortierung nach politischem Spektrum (DE-Standard)
+        // 1. Sortieren nach politischer Position
         List<Party> sortedParties = parties.stream()
                 .filter(p -> !p.getName().equals(SimulationConfig.UNDECIDED_NAME))
-                .sorted(new SpectrumComparator())
+                .sorted(Comparator.comparingDouble(Party::getPoliticalPosition))
                 .collect(Collectors.toList());
 
-        // 2. Farb-Liste erstellen (Ein Eintrag pro Sitz)
-        List<String> seatColorMap = new ArrayList<>();
-
-        for (Party p : sortedParties) {
-            double share = (totalVotes > 0) ? p.getCurrentSupporterCount() / totalVotes : 0;
-            int seatsForParty = (int) Math.round(share * TOTAL_SEATS);
-
-            for (int i = 0; i < seatsForParty; i++) {
-                if (seatColorMap.size() < TOTAL_SEATS) {
-                    seatColorMap.add(p.getColorCode());
-                }
+        // 2. Sitze verteilen (Exakt TOTAL_SEATS füllen)
+        List<Party> seatPartyMap = new ArrayList<>();
+        if (totalVotes > 0) {
+            for (Party p : sortedParties) {
+                double share = p.getCurrentSupporterCount() / totalVotes;
+                int seatsForParty = (int) Math.round(share * TOTAL_SEATS);
+                for (int i = 0; i < seatsForParty; i++) seatPartyMap.add(p);
             }
         }
-        // Auffüllen mit Grau, falls Rundungsfehler
-        while (seatColorMap.size() < TOTAL_SEATS) {
-            seatColorMap.add("444444");
+
+        // Trimmen oder Auffüllen, um exakt TOTAL_SEATS zu erreichen
+        while (seatPartyMap.size() > TOTAL_SEATS) {
+            seatPartyMap.remove(seatPartyMap.size() - 1);
+        }
+        while (seatPartyMap.size() < TOTAL_SEATS) {
+            seatPartyMap.add(null); // Leere Sitze auffüllen
         }
 
-        // 3. Geometrische Berechnung der Sitze (Halbkreis)
-        // Wir berechnen ALLE Sitzpositionen im Saal, sortieren sie von Links nach Rechts
-        // und weisen dann die Farben zu. Das garantiert perfekte Blöcke.
-
+        // 3. Geometrie berechnen (Verteilung auf Reihen)
         List<Point> layoutPoints = new ArrayList<>();
-        double startRadius = 100.0;
-        double rowStep = 25.0; // Engere Reihen
+
+        // Gesamtbogenlänge berechnen
+        double totalArcLen = 0;
+        for (int r = 0; r < ROWS; r++) {
+            totalArcLen += Math.PI * (START_RADIUS + r * ROW_STEP);
+        }
+
+        int seatsGenerated = 0;
 
         for (int row = 0; row < ROWS; row++) {
-            double currentRadius = startRadius + (row * rowStep);
+            double currentRadius = START_RADIUS + (row * ROW_STEP);
             double arcLength = Math.PI * currentRadius;
 
-            // Proportionale Anzahl Sitze pro Reihe
-            double totalArcParams = 0;
-            for(int r=0; r<ROWS; r++) totalArcParams += Math.PI * (startRadius + (r * rowStep));
-            int seatsInRow = (int) (TOTAL_SEATS * (arcLength / totalArcParams));
+            // Anteilige Sitze für diese Reihe
+            int seatsInRow = (int) Math.round(TOTAL_SEATS * (arcLength / totalArcLen));
 
-            double angleStep = Math.PI / (seatsInRow + 1);
+            // Korrektur für die letzte Reihe, damit Summe stimmt
+            if (row == ROWS - 1) {
+                seatsInRow = TOTAL_SEATS - seatsGenerated;
+            }
+            seatsGenerated += seatsInRow;
+
+            // Winkelberechnung: Voller Bogen von PI bis 0
+            double angleStep = (seatsInRow > 1) ? Math.PI / (seatsInRow - 1) : 0;
 
             for (int s = 0; s < seatsInRow; s++) {
-                // Winkel von PI (Links) bis 0 (Rechts)
-                double angle = Math.PI - (angleStep * (s + 1));
+                double angle;
+                if (seatsInRow > 1) {
+                    // Start bei PI (Links), Ende bei 0 (Rechts)
+                    angle = Math.PI - (angleStep * s);
+                } else {
+                    angle = Math.PI / 2; // Mitte
+                }
 
-                // Koordinaten (Relativ zur Mitte)
                 double x = Math.cos(angle) * currentRadius;
-                double y = -Math.sin(angle) * currentRadius; // Nach oben
-
-                // Wir speichern den Winkel für die spätere Sortierung
+                double y = -Math.sin(angle) * currentRadius;
                 layoutPoints.add(new Point(x, y, angle));
             }
         }
 
-        // 4. Sortieren der physikalischen Plätze von LINKS (großer Winkel) nach RECHTS (kleiner Winkel)
-        // Damit füllen wir die Parteien "streifenweise" auf.
+        // Sortieren von Links nach Rechts
         layoutPoints.sort((p1, p2) -> Double.compare(p2.angle, p1.angle));
 
-        // 5. Farben zuweisen
-        int limit = Math.min(layoutPoints.size(), seatColorMap.size());
+        // 4. Mapping: Geometrie auf Parteien
+        int limit = Math.min(layoutPoints.size(), seatPartyMap.size());
         for (int i = 0; i < limit; i++) {
             Point pt = layoutPoints.get(i);
-            seats.add(new Seat(pt.x, pt.y, seatColorMap.get(i)));
-        }
-    }
-
-    /**
-     * Sortiert Parteien nach deutscher Parlamentslogik (Links -> Rechts).
-     */
-    private static class SpectrumComparator implements Comparator<Party> {
-        @Override
-        public int compare(Party p1, Party p2) {
-            return Integer.compare(getSpectrumIndex(p1), getSpectrumIndex(p2));
-        }
-
-        private int getSpectrumIndex(Party p) {
-            String name = p.getName().toLowerCase();
-            String abbr = p.getAbbreviation().toLowerCase();
-
-            // Index: 0 (Links) bis 10 (Rechts)
-            if (name.contains("linke") || abbr.contains("linke")) return 0;
-            if (name.contains("spd") || abbr.contains("spd") || name.contains("sozial")) return 1;
-            if (name.contains("grüne") || abbr.contains("grüne") || name.contains("green")) return 2;
-            if (name.contains("fdp") || abbr.contains("fdp") || name.contains("libera")) return 3;
-            if (name.contains("cdu") || abbr.contains("cdu") || name.contains("csu") || name.contains("christ")) return 4;
-            if (name.contains("afd") || abbr.contains("afd") || name.contains("alternative")) return 5;
-
-            return 10; // Sonstige (ganz rechts außen oder separat)
+            Party p = seatPartyMap.get(i);
+            int row = (int) Math.round((Math.sqrt(pt.x*pt.x + pt.y*pt.y) - START_RADIUS) / ROW_STEP);
+            seats.add(new Seat(pt.x, pt.y, pt.angle, row, p));
         }
     }
 
     private void startAnimation() {
+        if (animationLoop != null) animationLoop.stop();
+        time = 0.0;
         final long startNano = System.nanoTime();
-        introAnimation = new AnimationTimer() {
+        animationLoop = new AnimationTimer() {
             @Override
             public void handle(long now) {
                 double t = (now - startNano) / 1_000_000_000.0;
+                time = t;
                 draw(t);
-                if (t > 2.0) stop();
             }
         };
-        introAnimation.start();
+        animationLoop.start();
     }
 
-    private void draw(double time) {
-        GraphicsContext gc = canvas.getGraphicsContext2D();
+    // --- Drawing ---
+
+    private void draw(double t) {
         double w = canvas.getWidth();
         double h = canvas.getHeight();
-        double cx = w / 2;
-        double cy = h * 0.9; // Basis weit unten
+        if (w < 1 || h < 1) return;
 
+        GraphicsContext gc = canvas.getGraphicsContext2D();
         gc.clearRect(0, 0, w, h);
-        gc.setEffect(new Glow(0.6));
 
-        double scale = Math.min(w, h) / 600.0;
+        this.lastCx = w / 2;
+        this.lastCy = h * 0.9; // Basis weit unten
 
+        // Dynamische Skalierung inkl. Padding berechnen
+        double contentWidth = MAX_RADIUS * 2 + 80; // +Padding
+        double contentHeight = MAX_RADIUS + 80;
+        double scaleW = w / contentWidth;
+        double scaleH = h / contentHeight;
+        this.lastScale = Math.min(scaleW, scaleH);
+
+        if (lastScale < 0.1) return;
+
+        drawBackground(gc, lastCx, lastCy, lastScale, t);
+        drawNetwork(gc, lastCx, lastCy, lastScale, t);
+
+        // Sitze zeichnen
         for (Seat seat : seats) {
-            // Sweep von Links nach Rechts
-            double normalizedX = (seat.x + 400) / 800.0;
-            if (time < normalizedX * 1.5) continue;
+            double animOffset = Math.max(0, 1.0 - (t * 2.0 - (seat.row * 0.1)));
+            double currentScale = lastScale * (1.0 + animOffset * 0.5);
+            double alpha = Math.min(1.0, t * 2.0 - (seat.row * 0.1));
 
-            gc.setFill(Color.web("#" + seat.color));
-            double drawX = cx + (seat.x * scale);
-            double drawY = cy + (seat.y * scale);
-            double size = 7.0 * scale;
+            if (alpha <= 0) continue;
 
-            gc.fillOval(drawX - size/2, drawY - size/2, size, size);
+            // Logik für Hover/Selektion
+            boolean isEmpty = (seat.party == null);
+            boolean isSelected = (!isEmpty && selectedParty != null && selectedParty.equals(seat.party));
+            boolean isHovered = (!isEmpty && hoveredParty != null && hoveredParty.equals(seat.party));
+            boolean anySelection = (selectedParty != null);
+
+            if (isSelected) {
+                gc.setGlobalAlpha(1.0);
+                gc.setEffect(new Glow(0.8));
+            } else if (isHovered && !anySelection) {
+                gc.setGlobalAlpha(1.0);
+                gc.setEffect(new Glow(0.5));
+            } else if (anySelection) {
+                gc.setGlobalAlpha(0.2);
+                gc.setEffect(null);
+            } else {
+                gc.setGlobalAlpha(isEmpty ? 0.3 : alpha);
+                gc.setEffect(null);
+            }
+
+            double x = lastCx + (seat.x * currentScale);
+            double y = lastCy + (seat.y * currentScale);
+
+            Color c = isEmpty ? COL_EMPTY_SEAT : Color.GRAY;
+            if (!isEmpty) {
+                try { c = Color.web(seat.party.getColorCode()); } catch(Exception e) {}
+            }
+
+            // Sitz-Rechteck
+            gc.setFill(c.deriveColor(0, 1, 1, 0.4));
+            double size = 8.5 * lastScale;
+            gc.fillRect(x - size/2, y - size/2, size, size);
+
+            // Kern
+            if (!isEmpty) {
+                gc.setFill(c);
+                double coreSize = 3.5 * lastScale;
+                gc.fillRect(x - coreSize/2, y - coreSize/2, coreSize, coreSize);
+            }
         }
 
-        // Pult
-        gc.setFill(Color.web("#555555"));
-        gc.fillRect(cx - 30*scale, cy - 10*scale, 60*scale, 20*scale);
-
+        gc.setGlobalAlpha(1.0);
         gc.setEffect(null);
+
+        drawMarkers(gc, lastCx, lastCy, lastScale);
+        drawHUD(gc, w, h);
     }
 
-    private static class Point { double x, y, angle; Point(double x, double y, double a) {this.x=x; this.y=y; this.angle=a;} }
-    private static class Seat { double x, y; String color; Seat(double x, double y, String c) {this.x=x; this.y=y; this.color=c;} }
+    private void drawBackground(GraphicsContext gc, double cx, double cy, double scale, double t) {
+        gc.setLineWidth(1.0);
+        double outerR = (MAX_RADIUS + 20) * scale;
+
+        gc.setStroke(Color.web("#222222"));
+        gc.setLineDashes(5, 5);
+        gc.strokeOval(cx - outerR, cy - outerR, outerR*2, outerR*2);
+
+        gc.setStroke(COL_BG_LINES);
+        gc.setLineDashes(null);
+        // Strahlen
+        for(int ang = 0; ang <= 180; ang += 15) {
+            double rad = Math.toRadians(ang);
+            double len = (MAX_RADIUS + 40) * scale;
+            gc.strokeLine(cx, cy, cx + Math.cos(rad)*len, cy - Math.sin(rad)*len);
+        }
+
+        // Scan Effekt
+        double scanR = (t * 250) % (MAX_RADIUS * 1.5);
+        double rSc = scanR * scale;
+        gc.setStroke(new LinearGradient(0,0,1,1, true, CycleMethod.NO_CYCLE,
+                new Stop(0, Color.TRANSPARENT), new Stop(0.5, Color.web("#D4AF37", 0.15)), new Stop(1, Color.TRANSPARENT)));
+        gc.strokeOval(cx - rSc, cy - rSc, rSc*2, rSc*2);
+    }
+
+    private void drawNetwork(GraphicsContext gc, double cx, double cy, double scale, double t) {
+        gc.setStroke(Color.web("#D4AF37", 0.05));
+        gc.setLineWidth(1.0);
+        int step = 10;
+        for(int i=0; i<seats.size(); i+=step) {
+            Seat s = seats.get(i);
+            if(s.party != null && t > 0.5) {
+                double sx = cx + s.x * scale;
+                double sy = cy + s.y * scale;
+                gc.strokeLine(sx, sy, cx, cy + 20*scale);
+            }
+        }
+    }
+
+    private void drawMarkers(GraphicsContext gc, double cx, double cy, double scale) {
+        double r = (MAX_RADIUS + 15) * scale;
+        gc.setFont(Font.font("Consolas", FontWeight.NORMAL, 9));
+        gc.setTextAlign(TextAlignment.CENTER);
+        gc.setStroke(COL_GOLD_DIM);
+        gc.setFill(COL_TEXT);
+
+        int idx = 1;
+        for(int ang=0; ang<=180; ang+=30) {
+            double rad = Math.toRadians(ang);
+            double x1 = cx + Math.cos(rad) * (r - 5);
+            double y1 = cy - Math.sin(rad) * (r - 5);
+            double x2 = cx + Math.cos(rad) * (r + 10);
+            double y2 = cy - Math.sin(rad) * (r + 10);
+
+            gc.strokeLine(x1, y1, x2, y2);
+
+            double tx = cx + Math.cos(rad) * (r + 25);
+            double ty = cy - Math.sin(rad) * (r + 25);
+
+            String lbl = (ang==90) ? "CENTER" : String.format("SEC-%02d", idx++);
+            gc.fillText(lbl, tx, ty + 4);
+        }
+    }
+
+    private void drawHUD(GraphicsContext gc, double w, double h) {
+        // Header
+        gc.setFill(new LinearGradient(0,0,0,1, true, CycleMethod.NO_CYCLE,
+                new Stop(0, Color.web("#000000",0.8)), new Stop(1, Color.TRANSPARENT)));
+        gc.fillRect(0,0,w,60);
+
+        // Pult
+        double cx = w/2;
+        double cy = h * 0.9;
+        gc.setStroke(COL_GOLD);
+        gc.setLineWidth(1);
+        gc.strokeLine(cx-50, cy+20, cx+50, cy+20);
+        gc.strokeLine(cx-50, cy+20, cx-60, cy+30);
+        gc.strokeLine(cx+50, cy+20, cx+60, cy+30);
+
+        gc.setFill(COL_GOLD);
+        gc.setTextAlign(TextAlignment.CENTER);
+        gc.setFont(Font.font("Consolas", FontWeight.BOLD, 12));
+        gc.fillText("COMMAND_PODIUM", cx, cy+45);
+
+        gc.setTextAlign(TextAlignment.LEFT);
+        gc.setFill(COL_TEXT);
+        gc.fillText("ENCRYPTION: AES-256", 20, h-20);
+    }
+
+    // --- Helper ---
+    private static class Point { double x, y, angle; Point(double x, double y, double a){this.x=x;this.y=y;this.angle=a;}}
+    private static class Seat {
+        double x, y, angle; int row; Party party;
+        Seat(double x, double y, double a, int r, Party p){this.x=x;this.y=y;this.angle=a;this.row=r;this.party=p;}
+    }
 }

--- a/src/main/resources/de/schulprojekt/duv/parliament.css
+++ b/src/main/resources/de/schulprojekt/duv/parliament.css
@@ -1,0 +1,34 @@
+/* Düsterer Hintergrund mit Vignette */
+.main-background {
+    -fx-background-color: radial-gradient(center 50% 50%, radius 100%, #1a1a1a, #000000);
+}
+
+/* Cyberpunk/Neon Button Style */
+.neon-button {
+    -fx-background-color: transparent;
+    -fx-text-fill: #00ffaa;
+    -fx-border-color: #00ffaa;
+    -fx-border-width: 1px;
+    -fx-font-family: 'Consolas', 'Monospaced';
+    -fx-font-weight: bold;
+    -fx-cursor: hand;
+    -fx-padding: 8 15 8 15;
+    -fx-effect: dropshadow(three-pass-box, rgba(0, 255, 170, 0.4), 10, 0, 0, 0);
+    -fx-transition: all 0.3s;
+}
+
+.neon-button:hover {
+    -fx-background-color: rgba(0, 255, 170, 0.1);
+    -fx-effect: dropshadow(three-pass-box, rgba(0, 255, 170, 0.8), 15, 0, 0, 0);
+    -fx-scale-x: 1.05;
+    -fx-scale-y: 1.05;
+}
+
+.neon-button:pressed {
+    -fx-background-color: rgba(0, 255, 170, 0.2);
+    -fx-effect: dropshadow(three-pass-box, rgba(0, 255, 170, 1.0), 5, 0, 0, 0);
+}
+
+.header-label {
+    -fx-effect: dropshadow(gaussian, rgba(85, 255, 85, 0.6), 10, 0.5, 0, 0);
+}

--- a/src/main/resources/de/schulprojekt/duv/parliament.css
+++ b/src/main/resources/de/schulprojekt/duv/parliament.css
@@ -1,34 +1,82 @@
-/* Düsterer Hintergrund mit Vignette */
+/* =========================================================================
+   === PARLIAMENT.CSS - SECRET SERVICE EDITION ===
+   ========================================================================= */
+
+/* Nutzt die Basis aus common.css, hier spezifische Anpassungen */
+
+/* Hintergrund: Tiefschwarz mit taktischem Overlay (passend zum Dashboard) */
 .main-background {
-    -fx-background-color: radial-gradient(center 50% 50%, radius 100%, #1a1a1a, #000000);
+    -fx-background-color: #050508;
 }
 
-/* Cyberpunk/Neon Button Style */
-.neon-button {
-    -fx-background-color: transparent;
-    -fx-text-fill: #00ffaa;
-    -fx-border-color: #00ffaa;
+/* Optional: Fügt das Gitter hinzu, falls du ein Pane mit dieser Klasse im FXML hast
+   (Empfehlung: Füge 'grid-background' im FXML zum Root oder Center hinzu) */
+.grid-overlay {
+    -fx-background-color:
+            linear-gradient(from 0px 0px to 40px 0px, repeat, rgba(212, 175, 55, 0.05) 0%, rgba(212, 175, 55, 0.05) 1px, transparent 1px, transparent 100%),
+            linear-gradient(from 0px 0px to 0px 40px, repeat, rgba(212, 175, 55, 0.05) 0%, rgba(212, 175, 55, 0.05) 1px, transparent 1px, transparent 100%);
+}
+
+/* Der Zurück-Button im Military-Style (Gold statt Neon-Cyan) */
+.nav-button {
+    -fx-background-color: rgba(212, 175, 55, 0.1);
+    -fx-text-fill: #D4AF37;
+    -fx-border-color: #D4AF37;
     -fx-border-width: 1px;
     -fx-font-family: 'Consolas', 'Monospaced';
     -fx-font-weight: bold;
     -fx-cursor: hand;
     -fx-padding: 8 15 8 15;
-    -fx-effect: dropshadow(three-pass-box, rgba(0, 255, 170, 0.4), 10, 0, 0, 0);
+    /* Leichter Gold-Glow */
+    -fx-effect: dropshadow(three-pass-box, rgba(212, 175, 55, 0.2), 10, 0, 0, 0);
     -fx-transition: all 0.3s;
 }
 
-.neon-button:hover {
-    -fx-background-color: rgba(0, 255, 170, 0.1);
-    -fx-effect: dropshadow(three-pass-box, rgba(0, 255, 170, 0.8), 15, 0, 0, 0);
-    -fx-scale-x: 1.05;
-    -fx-scale-y: 1.05;
+.nav-button:hover {
+    -fx-background-color: rgba(212, 175, 55, 0.25);
+    -fx-effect: dropshadow(three-pass-box, rgba(212, 175, 55, 0.6), 15, 0, 0, 0);
+    -fx-scale-x: 1.02;
+    -fx-scale-y: 1.02;
 }
 
-.neon-button:pressed {
-    -fx-background-color: rgba(0, 255, 170, 0.2);
-    -fx-effect: dropshadow(three-pass-box, rgba(0, 255, 170, 1.0), 5, 0, 0, 0);
+.nav-button:pressed {
+    -fx-background-color: #D4AF37;
+    -fx-text-fill: #050508;
+    -fx-effect: dropshadow(three-pass-box, rgba(212, 175, 55, 0.8), 5, 0, 0, 0);
 }
 
+/* Titel-Label: Gold mit Glow (statt Grün) */
 .header-label {
-    -fx-effect: dropshadow(gaussian, rgba(85, 255, 85, 0.6), 10, 0.5, 0, 0);
+    -fx-text-fill: #D4AF37;
+    -fx-font-family: "Consolas", monospace;
+    -fx-font-weight: bold;
+    -fx-effect: dropshadow(gaussian, rgba(212, 175, 55, 0.4), 10, 0.3, 0, 0);
+}
+
+/* Untertitel: Matrix-Grün (für technische Daten/Status) */
+.sub-header-label {
+    -fx-text-fill: #00ff41;
+    -fx-font-family: "Consolas", monospace;
+    -fx-font-size: 10px;
+    -fx-opacity: 0.8;
+}
+
+/* Footer Status: Dezent Grau/Grün */
+.footer-status {
+    -fx-text-fill: #444444;
+    -fx-font-family: 'Consolas', monospace;
+}
+
+/* --- CRT Scanlines Overlay (Alter Monitor Effekt) --- */
+.crt-overlay {
+    /* Simuliert feine horizontale Scanlines */
+    -fx-background-color: linear-gradient(from 0px 0px to 0px 4px, repeat, transparent 0%, transparent 50%, rgba(0, 0, 0, 0.4) 50%, rgba(0, 0, 0, 0.4) 100%);
+    -fx-opacity: 0.3;
+    -fx-mouse-transparent: true; /* WICHTIG: Klicks gehen durch den Effekt hindurch */
+}
+
+/* Optional: Leichte Vignette für den Röhren-Look (abgedunkelte Ecken) */
+.vignette-overlay {
+    -fx-background-color: radial-gradient(center 50% 50%, radius 100%, transparent 60%, rgba(0, 0, 0, 0.6) 100%);
+    -fx-mouse-transparent: true;
 }

--- a/src/main/resources/de/schulprojekt/duv/view/DashboardUI.fxml
+++ b/src/main/resources/de/schulprojekt/duv/view/DashboardUI.fxml
@@ -50,6 +50,11 @@
                         <Button fx:id="pauseButton" text="⏸ FREEZE" onAction="#handlePauseSimulation" disable="true"/>
                         <Button fx:id="resetButton" text="↺ REBOOT" onAction="#handleResetSimulation" disable="true"/>
                         <Button fx:id="statsButton" text="📊 INTEL" onAction="#handleShowStatistics" style="-fx-base: #222;"/>
+                        <Button fx:id="parliamentButton"
+                                text="PARLIAMENT"
+                                onAction="#handleShowParliament"
+                                styleClass="action-button">
+                        </Button>
                     </HBox>
                 </VBox>
             </VBox>

--- a/src/main/resources/de/schulprojekt/duv/view/ParliamentView.fxml
+++ b/src/main/resources/de/schulprojekt/duv/view/ParliamentView.fxml
@@ -4,33 +4,38 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.*?>
 
-<BorderPane xmlns="http://javafx.com/javafx"
-            xmlns:fx="http://javafx.com/fxml"
-            fx:controller="de.schulprojekt.duv.view.ParliamentController"
-            stylesheets="@../parliament.css"
-            styleClass="main-background">
+<StackPane xmlns="http://javafx.com/javafx"
+           xmlns:fx="http://javafx.com/fxml"
+           fx:controller="de.schulprojekt.duv.view.ParliamentController"
+           stylesheets="@../parliament.css">
 
-    <top>
-        <HBox alignment="CENTER_LEFT" spacing="20" style="-fx-padding: 20;">
-            <Button text="&lt; SYSTEM_RETURN" onAction="#handleBack" styleClass="neon-button"/>
+    <BorderPane styleClass="main-background">
+        <top>
+            <HBox alignment="CENTER_LEFT" spacing="20" style="-fx-padding: 20;">
+                <Button text="&lt; SYSTEM_RETURN" onAction="#handleBack" styleClass="nav-button"/>
 
-            <VBox>
-                <Label text="SEAT_DISTRIBUTION // HEMICYCLE_VIEW" textFill="#55ff55" styleClass="header-label">
-                    <font><Font name="Consolas Bold" size="24"/></font>
-                </Label>
-                <Label text="LIVE_SIMULATION_FEED::VOTER_MAPPING" textFill="#00aa88" style="-fx-font-family: 'Consolas'; -fx-font-size: 10px;"/>
-            </VBox>
-        </HBox>
-    </top>
+                <VBox>
+                    <Label text="SEAT_DISTRIBUTION // HEMICYCLE_VIEW" styleClass="header-label">
+                        <font><Font name="Consolas Bold" size="24"/></font>
+                    </Label>
+                    <Label text="LIVE_SIMULATION_FEED::VOTER_MAPPING" styleClass="sub-header-label"/>
+                </VBox>
+            </HBox>
+        </top>
 
-    <center>
-        <Pane fx:id="canvasContainer" style="-fx-background-color: transparent;" />
-    </center>
+        <center>
+            <Pane fx:id="canvasContainer" styleClass="grid-overlay"/>
+        </center>
 
-    <bottom>
-        <HBox alignment="CENTER" style="-fx-padding: 10;">
-            <Label text="[SECURE CONNECTION ESTABLISHED]" textFill="#444444" style="-fx-font-family: 'Consolas';"/>
-        </HBox>
-    </bottom>
+        <bottom>
+            <HBox alignment="CENTER" style="-fx-padding: 10;">
+                <Label text="[SECURE CONNECTION ESTABLISHED]" styleClass="footer-status"/>
+            </HBox>
+        </bottom>
+    </BorderPane>
 
-</BorderPane>
+    <Pane styleClass="crt-overlay" mouseTransparent="true"/>
+
+    <Pane styleClass="vignette-overlay" mouseTransparent="true"/>
+
+</StackPane>

--- a/src/main/resources/de/schulprojekt/duv/view/ParliamentView.fxml
+++ b/src/main/resources/de/schulprojekt/duv/view/ParliamentView.fxml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
+
+<BorderPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml"
+            fx:controller="de.schulprojekt.duv.view.ParliamentController"
+            stylesheets="@../parliament.css"
+            styleClass="main-background">
+
+    <top>
+        <HBox alignment="CENTER_LEFT" spacing="20" style="-fx-padding: 20;">
+            <Button text="&lt; SYSTEM_RETURN" onAction="#handleBack" styleClass="neon-button"/>
+
+            <VBox>
+                <Label text="SEAT_DISTRIBUTION // HEMICYCLE_VIEW" textFill="#55ff55" styleClass="header-label">
+                    <font><Font name="Consolas Bold" size="24"/></font>
+                </Label>
+                <Label text="LIVE_SIMULATION_FEED::VOTER_MAPPING" textFill="#00aa88" style="-fx-font-family: 'Consolas'; -fx-font-size: 10px;"/>
+            </VBox>
+        </HBox>
+    </top>
+
+    <center>
+        <Pane fx:id="canvasContainer" style="-fx-background-color: transparent;" />
+    </center>
+
+    <bottom>
+        <HBox alignment="CENTER" style="-fx-padding: 10;">
+            <Label text="[SECURE CONNECTION ESTABLISHED]" textFill="#444444" style="-fx-font-family: 'Consolas';"/>
+        </HBox>
+    </bottom>
+
+</BorderPane>


### PR DESCRIPTION
This pull request introduces a new Parliament view to the application, allowing users to visualize the distribution of parties in parliament with interactive tooltips. It adds a dedicated controller and integrates the view-switching logic into the dashboard. Additionally, the `TooltipManager` has been refactored to support both dynamic tooltips for the dashboard and static tooltips for the parliament view, with improved code structure and clearer separation of concerns.

**New Parliament View Integration:**

* Added a new `ParliamentController` class that manages the parliament view, including rendering party distributions and handling user interactions such as hover and click for selection and tooltips. (`src/main/java/de/schulprojekt/duv/view/ParliamentController.java`)
* Integrated a new handler `handleShowParliament` in `DashboardController` to switch from the dashboard to the parliament view, pausing the simulation if necessary and passing required data. (`src/main/java/de/schulprojekt/duv/view/DashboardController.java`)

**Tooltip System Refactoring and Enhancement:**

* Refactored `TooltipManager` to support two modes: dynamic tooltips for the dashboard (on hover) and static tooltips for the parliament view (on click), with clearer method separation and improved parameter handling. (`src/main/java/de/schulprojekt/duv/view/components/TooltipManager.java`) [[1]](diffhunk://#diff-780dc0c15a14c6654a8dd5baa4b884176fc1bb44402f6fa5fd3a71b09a3e6fb2R21-R31) [[2]](diffhunk://#diff-780dc0c15a14c6654a8dd5baa4b884176fc1bb44402f6fa5fd3a71b09a3e6fb2L128-R224)
* Improved tooltip positioning logic to better handle screen boundaries and anchor tooltips visually to party positions in both views. (`src/main/java/de/schulprojekt/duv/view/components/TooltipManager.java`)

**Project Configuration Updates:**

* Updated `.idea/workspace.xml` to reflect changes in the active changelist, recently opened files, and the placeholder for the git widget to the Parliament screen. [[1]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL7-R10) [[2]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL58-R92) [[3]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cR201)